### PR TITLE
Add compose setup and env example

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,0 +1,11 @@
+{$NC_DOMAIN} {
+    reverse_proxy localhost:11000
+}
+
+{$NC_DOMAIN}:8443 {
+    reverse_proxy https://localhost:8080 {
+        transport http {
+            tls_insecure_skip_verify
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+services:
+  nextcloud-aio-mastercontainer:
+    image: ghcr.io/nextcloud-releases/all-in-one:latest
+    container_name: nextcloud-aio-mastercontainer
+    init: true
+    restart: always
+    environment:
+      APACHE_PORT: 11000
+      APACHE_IP_BINDING: 127.0.0.1
+    volumes:
+      - nextcloud_aio_mastercontainer:/mnt/docker-aio-config
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    ports:
+      - "8080:8080"
+    network_mode: bridge
+
+  caddy:
+    image: caddy:alpine
+    container_name: caddy
+    restart: always
+    network_mode: host
+    volumes:
+      - caddy_certs:/certs
+      - caddy_config:/config
+      - caddy_data:/data
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+    environment:
+      - NC_DOMAIN
+
+volumes:
+  nextcloud_aio_mastercontainer:
+  caddy_certs:
+  caddy_config:
+  caddy_data:

--- a/env.example
+++ b/env.example
@@ -1,0 +1,3 @@
+# Example environment variables for docker-compose.yml
+# Set the domain that should be used for Nextcloud
+NC_DOMAIN=yourdomain.com


### PR DESCRIPTION
## Summary
- add a `docker-compose.yml` that mirrors the zero-touch setup
- add a `caddy/Caddyfile` template used by docker compose
- provide `env.example` for required variables

## Testing
- `git status --short`